### PR TITLE
fix: Support for User Credentials

### DIFF
--- a/kafka-java-auth/pom.xml
+++ b/kafka-java-auth/pom.xml
@@ -30,6 +30,11 @@
       <version>1.23.0</version>
     </dependency>
     <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-oauth2</artifactId>
+      <version>v2-rev131-1.23.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
       <version>3.7.0</version>

--- a/kafka-java-auth/src/main/java/com/google/cloud/hosted/kafka/auth/GcpLoginCallbackHandler.java
+++ b/kafka-java-auth/src/main/java/com/google/cloud/hosted/kafka/auth/GcpLoginCallbackHandler.java
@@ -24,6 +24,7 @@ import com.google.auth.oauth2.ExternalAccountCredentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ImpersonatedCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.auth.oauth2.UserCredentials;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -127,6 +128,8 @@ public class GcpLoginCallbackHandler implements AuthenticateCallbackHandler {
       subject = ((ImpersonatedCredentials) credentials).getAccount();
     } else if (credentials instanceof StubGoogleCredentials) {
       subject = ((StubGoogleCredentials) credentials).getAccount();
+    } else if(credentials instanceof UserCredentials) {
+      subject = null;
     } else {
       throw new IOException("Unknown credentials type: " + credentials.getClass().getName());
     }


### PR DESCRIPTION
I faced issue: Unknown credentials type UserCredentials
steps to reproduce:

gcloud auth application-default login
configure callback handler in properties
run kafka producer
Fix is to add support for UserCredentials and pull subject. 