### PR TITLE
fix: Update Managed Kafka Auth Dependency To Be Compatible With Java 8

### DIFF
--- a/kafka-java-auth/pom.xml
+++ b/kafka-java-auth/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud.hosted.kafka</groupId>
   <artifactId>managed-kafka-auth-login-handler</artifactId>
-  <version>1.0.1-SNAPSHOT</version><!-- {x-version-update:pubsublite-kafka:current} -->
+  <version>1.0.2-SNAPSHOT</version><!-- {x-version-update:pubsublite-kafka:current} -->
   <packaging>jar</packaging>
   <name>Managed Kafka Auth</name>
   <url>https://github.com/googleapis/managedkafka</url>
@@ -27,7 +27,7 @@
     <connection>scm:git:git@github.com:googleapis/managedkafka.git/kafka-java-auth</connection>
     <developerConnection>scm:git:git@github.com:googleapis/managedkafka.git/kafka-java-auth</developerConnection>
     <url>https://github.com/googleapis/managedkafka</url>
-    <tag>managed-kafka-auth-login-handler-1.0.1</tag>
+    <tag>managed-kafka-auth-login-handler-1.0.2</tag>
   </scm>
   <licenses>
     <license>
@@ -37,7 +37,7 @@
     </license>
   </licenses>
   <properties>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>8</maven.compiler.release>
   </properties>
   <dependencies>
     <dependency>

--- a/kafka-java-auth/src/main/java/com/google/cloud/hosted/kafka/auth/GcpLoginCallbackHandler.java
+++ b/kafka-java-auth/src/main/java/com/google/cloud/hosted/kafka/auth/GcpLoginCallbackHandler.java
@@ -132,10 +132,10 @@ public class GcpLoginCallbackHandler implements AuthenticateCallbackHandler {
       throw new IOException("Unknown credentials type: " + credentials.getClass().getName());
     }
     credentials.refreshIfExpired();
-    var googleAccessToken = credentials.getAccessToken();
+    AccessToken googleAccessToken = credentials.getAccessToken();
     String kafkaToken = getKafkaAccessToken(googleAccessToken, subject);
 
-    var now = Instant.now();
+    Instant now = Instant.now();
     OAuthBearerToken token =
         new BasicOAuthBearerToken(
             kafkaToken,

--- a/kafka-java-auth/src/test/java/com/google/cloud/hosted/kafka/auth/GcpLoginCallbackHandlerTest.java
+++ b/kafka-java-auth/src/test/java/com/google/cloud/hosted/kafka/auth/GcpLoginCallbackHandlerTest.java
@@ -59,9 +59,9 @@ public final class GcpLoginCallbackHandlerTest {
   static class UnsupportedCredentials extends GoogleCredentials {}
 
   public GcpLoginCallbackHandler createHandler(GoogleCredentials credentials) throws Exception {
-    var gcpLoginCallbackHandler = new GcpLoginCallbackHandler(credentials);
-    var configs = new HashMap<String, Object>();
-    var jaasConfig = new ArrayList<AppConfigurationEntry>();
+    GcpLoginCallbackHandler gcpLoginCallbackHandler = new GcpLoginCallbackHandler(credentials);
+    HashMap configs = new HashMap<String, Object>();
+    ArrayList jaasConfig = new ArrayList<AppConfigurationEntry>();
     jaasConfig.add(
         new AppConfigurationEntry(
             "OAuthBearerLoginModule",
@@ -74,11 +74,11 @@ public final class GcpLoginCallbackHandlerTest {
 
   @Test
   public void success() throws Exception {
-    var now = Instant.now();
-    var oauthBearerTokenCallback = new OAuthBearerTokenCallback();
+    Instant now = Instant.now();
+    OAuthBearerTokenCallback oauthBearerTokenCallback = new OAuthBearerTokenCallback();
     Callback[] callbacks = {oauthBearerTokenCallback};
 
-    var gcpOAuthBearerLoginCallbackHandler = createHandler(new FakeGoogleCredentials());
+    GcpLoginCallbackHandler gcpOAuthBearerLoginCallbackHandler = createHandler(new FakeGoogleCredentials());
     gcpOAuthBearerLoginCallbackHandler.handle(callbacks);
 
     OAuthBearerToken oauthBearerToken = oauthBearerTokenCallback.token();
@@ -103,10 +103,10 @@ public final class GcpLoginCallbackHandlerTest {
 
   @Test
   public void fail_unsupportedCredentialType() throws Exception {
-    var oauthBearerTokenCallback = new OAuthBearerTokenCallback();
+    OAuthBearerTokenCallback oauthBearerTokenCallback = new OAuthBearerTokenCallback();
     Callback[] callbacks = {oauthBearerTokenCallback};
 
-    var gcpOAuthBearerLoginCallbackHandler = createHandler(new UnsupportedCredentials());
+    GcpLoginCallbackHandler gcpOAuthBearerLoginCallbackHandler = createHandler(new UnsupportedCredentials());
     assertThrows(IOException.class, () -> gcpOAuthBearerLoginCallbackHandler.handle(callbacks));
   }
 }


### PR DESCRIPTION
Update Managed Kafka package version and change maven release version to 8 to be compatible with Java 8. This is to extend the package's compatibility with beam, which supports Java 8.