### PR TITLE
chore: Relax the GKE WIF principal:// restriction

### DIFF
--- a/sasl-plain-access-token/segmentio/saslplainoauthmechanism/README.md
+++ b/sasl-plain-access-token/segmentio/saslplainoauthmechanism/README.md
@@ -9,7 +9,6 @@ It allows you to use Authorization Tokens with SASL/Plain in [segmentio/kafka-go
 saslplainoauthmechanism supports the following Application Default credential types:
 
 1. [GKE Workload Identity Federation](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity).
-    1. Note: Native Workload Identity Federation principals (`principal://` format) are currently unsupported, you must [link your Kubernetes Service Account](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#kubernetes-sa-to-iam) to a Google Service Account.
 2. [Metadata Server Credentials](https://cloud.google.com/docs/authentication/application-default-credentials#attached-sa) - Such as Google Compute Engine, Cloud Run, etc.
 3. [gcloud CLI Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials#personal). Specifically the following subset:
     1. `user_credentials` (`gcloud auth application-default login`).

--- a/sasl-plain-access-token/segmentio/saslplainoauthmechanism/principal_email_test.go
+++ b/sasl-plain-access-token/segmentio/saslplainoauthmechanism/principal_email_test.go
@@ -47,18 +47,39 @@ func TestValidatePrincipalEmail(t *testing.T) {
 			expectErr: false,
 		},
 		{
+			name:      "GKE WIF Principal - Valid",
+			email:     "principal://iam.googleapis.com/projects/1234567891011/locations/global/workloadIdentityPools/my-project.svc.id.goog/subject/ns/custom-namespace/sa/gmktest",
+			expectErr: false,
+		},
+		{
+			name:      "Standard Workload Identity Principal - Valid",
+			email:     "principal://iam.googleapis.com/projects/12345678/locations/global/workloadIdentityPools/my-pool/subject/my-subject",
+			expectErr: false,
+		},
+		{
+			name:      "Standard Workforce Identity Principal - Valid",
+			email:     "principal://iam.googleapis.com/locations/global/workforcePools/altostrat-contractors/subject/raha@altostrat.com",
+			expectErr: false,
+		},
+
+		{
 			name:      "Empty email - Invalid",
 			email:     "",
 			expectErr: true,
 		},
 		{
-			name:      "Workload Identity Federation Pool - No iam.gke.io/return-principal-id-as-email KSA annotation - Invalid",
-			email:     "my-project.svc.id.goog",
+			name:      "Non RFC Email - Invalid",
+			email:     "human[]principaluser@example.com",
 			expectErr: true,
 		},
 		{
-			name:      "Workload Identity Federation Principal - Invalid",
-			email:     "principal://iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/my-project.svc.id.goog/subject/ns/default/sa/gmktest",
+			name:      "Bad  WIF Principal Bad Prefix - Invalid",
+			email:     "principal://iammmmmmmm.googleapis.com/projects/1234567891011/locations/global/workloadIdentityPools/my-project.svc.id.goog/subject/ns/custom-namespace/sa/gmktest",
+			expectErr: true,
+		},
+		{
+			name:      "Workload Identity Federation Pool - No iam.gke.io/return-principal-id-as-email KSA annotation - Invalid",
+			email:     "my-project.svc.id.goog",
 			expectErr: true,
 		},
 	}


### PR DESCRIPTION
Submit once cl/749106195 is in prod.

Relax GKE WIF limitation. b/385138184.

```
Running tool: /usr/local/go/bin/go test -timeout 30s -run ^(TestNewMechanismWithTokenSource|TestMechanism_Name|TestMechanism_Start)$ github.com/googleapis/managedkafka/sasl-plain-access-token/segmentio/saslplainoauthmechanism

=== RUN   TestNewMechanismWithTokenSource
=== RUN   TestNewMechanismWithTokenSource/Valid_Token_and_Email
--- PASS: TestNewMechanismWithTokenSource/Valid_Token_and_Email (0.00s)
=== RUN   TestNewMechanismWithTokenSource/Valid_Token,_Bad_Email
--- PASS: TestNewMechanismWithTokenSource/Valid_Token,_Bad_Email (0.00s)
=== RUN   TestNewMechanismWithTokenSource/Token_Error
--- PASS: TestNewMechanismWithTokenSource/Token_Error (0.00s)
--- PASS: TestNewMechanismWithTokenSource (0.00s)
=== RUN   TestMechanism_Name
--- PASS: TestMechanism_Name (0.00s)
=== RUN   TestMechanism_Start
=== RUN   TestMechanism_Start/Valid_Token_and_Email
--- PASS: TestMechanism_Start/Valid_Token_and_Email (0.00s)
--- PASS: TestMechanism_Start (0.00s)
PASS
ok      github.com/googleapis/managedkafka/sasl-plain-access-token/segmentio/saslplainoauthmechanism    0.496s
```