### PR TITLE
Feat: Add ErrorMessage class for Schema Registry client.

### DIFF
--- a/kafka-java-auth/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/ErrorMessage.java
+++ b/kafka-java-auth/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/ErrorMessage.java
@@ -66,11 +66,13 @@ public class ErrorMessage {
   private int errorCode;
   private String message;
 
-  // Required for Jackson to instantiate the class when error_code/message
-  // fields are not present in the JSON message.
   public ErrorMessage() {}
 
-  // Required for compatibility with the old class.
+  // Required for compatibility with the original class.
+  // @JsonProperty("error_code") and @JsonProperty("message") annotations
+  // have been removed to force Jackson always use the default constructor
+  // and then set the values via either setErrorCode/setMessage or
+  // unpackNestedError methods.
   public ErrorMessage(int errorCode, String message) {
       this.errorCode = errorCode;
       this.message = message;
@@ -83,8 +85,8 @@ public class ErrorMessage {
   }
 
   @JsonProperty("error_code")
-  public void setErrorCode(int error_code) {
-    this.errorCode = error_code;
+  public void setErrorCode(int errorCode) {
+    this.errorCode = errorCode;
   }
 
   @Schema(description = "Detailed error message")
@@ -105,10 +107,10 @@ public class ErrorMessage {
     if (code != null) {
       try {
         this.errorCode = ((Integer) code);
-      } catch (Exception e1) {
+      } catch (RuntimeException e1) {
         try {
           this.errorCode = Integer.parseInt(code.toString());
-        } catch (Exception e2) {
+        } catch (RuntimeException e2) {
           // ignore if can't parse the error code as an integer
         }
       }

--- a/kafka-java-auth/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/ErrorMessage.java
+++ b/kafka-java-auth/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/ErrorMessage.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.client.rest.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Generic JSON error message.
+ *
+ * <p>This is an updated version of the original
+ * <code>io.confluent.kafka.schemaregistry.client.rest.entities.ErrorMessage</code>
+ * class from the Confluent Schema Registry Client, which has the same
+ * structure in Java and is still fully compatible with the client code,
+ * but supports parsing the source JSON error message in more formats
+ * via Jackson annotations (see {@link #unpackNestedError}).
+ *
+ * <p>In additional to the original error format:
+ * <pre>
+ *   {
+ *     "error_code": 400,
+ *     "message": "..."
+ *   }
+ * </pre>
+ * It also supports this format:
+ * <pre>
+ *   {
+ *     "error: {
+ *       "code": 400,
+ *       "message": "..."
+ *     }
+ *   }
+ * </pre>
+ *
+ * Since the class is in the same package
+ * <code>io.confluent.kafka.schemaregistry.client.rest.entities</code>,
+ * pre-pending this library to the classpath will override its implementation
+ * from the Schema Registry Client library and allow parsing Managed Kafka
+ * style error messages.
+ */
+@Schema(description = "Error message")
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ErrorMessage {
+
+  private int errorCode;
+  private String message;
+
+  // Required for Jackson to instantiate the class when error_code/message
+  // fields are not present in the JSON message.
+  public ErrorMessage() {}
+
+  // Required for compatibility with the old class.
+  public ErrorMessage(int errorCode, String message) {
+      this.errorCode = errorCode;
+      this.message = message;
+  }
+
+  @Schema(description = "Error code")
+  @JsonProperty("error_code")
+  public int getErrorCode() {
+    return errorCode;
+  }
+
+  @JsonProperty("error_code")
+  public void setErrorCode(int error_code) {
+    this.errorCode = error_code;
+  }
+
+  @Schema(description = "Detailed error message")
+  @JsonProperty
+  public String getMessage() {
+    return message;
+  }
+
+  @JsonProperty
+  public void setMessage(String message) {
+    this.message = message;
+  }
+
+  @JsonProperty("error")
+  public void unpackNestedError(Map<String, Object> error) {
+    Object code = error.get("code");
+
+    if (code != null) {
+      try {
+        this.errorCode = ((Integer) code);
+      } catch (Exception e1) {
+        try {
+          this.errorCode = Integer.parseInt(code.toString());
+        } catch (Exception e2) {
+          // ignore if can't parse the error code as an integer
+        }
+      }
+    }
+
+    String status = tryGetNonEmptyString(error.get("status"));
+    String message = tryGetNonEmptyString(error.get("message"));
+
+    if (message != null && status != null) {
+      this.message = status + ": " + message;
+    } else if (message != null) {
+      this.message = message;
+    } else if (status != null) {
+      this.message = status;
+    }
+  }
+
+  private static String tryGetNonEmptyString(Object object) {
+    if (object != null) {
+      String s = object.toString();
+      if (s.length() > 0) {
+        return s;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ErrorMessage that = (ErrorMessage) o;
+    return errorCode == that.errorCode
+        && Objects.equals(message, that.message);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(errorCode, message);
+  }
+}

--- a/kafka-java-auth/src/test/java/io/confluent/kafka/schemaregistry/client/rest/entities/ErrorMessageTest.java
+++ b/kafka-java-auth/src/test/java/io/confluent/kafka/schemaregistry/client/rest/entities/ErrorMessageTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.client.rest.entities;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ErrorMessageTest {
+  private JsonMapper mapper;
+
+  @Before
+  public void setup() {
+    this.mapper = JsonMapper.builder()
+        .enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)
+        .build();
+  }
+
+  @Test
+  public void success_parseUnnestedFields() throws Exception {
+    String json = "{\n"
+        + "  \"error_code\": 401,\n"
+        + "  \"message\": \"parseUnnestedFields\"\n"
+        + "}";
+
+    ErrorMessage em = mapper.readValue(json, ErrorMessage.class);
+
+    assertThat(em).isNotNull();
+    assertThat(em.getErrorCode()).isEqualTo(401);
+    assertThat(em.getMessage()).isEqualTo("parseUnnestedFields");
+  }
+
+  @Test
+  public void success_parseNestedFieldsWithStatus() throws Exception {
+    String json = "{\n"
+        + "  \"error\": {\n"
+        + "    \"code\": 402,\n"
+        + "    \"message\": \"parseNestedFields\",\n"
+        + "    \"status\": \"FAILED_PRECONDITION\"\n"
+        + "  }\n"
+        + "}";
+
+    ErrorMessage em = mapper.readValue(json, ErrorMessage.class);
+
+    assertThat(em).isNotNull();
+    assertThat(em.getErrorCode()).isEqualTo(402);
+    assertThat(em.getMessage()).isEqualTo("FAILED_PRECONDITION: parseNestedFields");
+  }
+
+  @Test
+  public void success_parseNestedFieldsWithoutStatus() throws Exception {
+    String json = "{\n"
+        + "  \"error\": {\n"
+        + "    \"code\": 402,\n"
+        + "    \"message\": \"parseNestedFields\"\n"
+        + "  }\n"
+        + "}";
+
+    ErrorMessage em = mapper.readValue(json, ErrorMessage.class);
+
+    assertThat(em).isNotNull();
+    assertThat(em.getErrorCode()).isEqualTo(402);
+    assertThat(em.getMessage()).isEqualTo("parseNestedFields");
+  }
+
+  @Test
+  public void success_parseNestedFieldsWithoutMessage() throws Exception {
+    String json = "{\n"
+        + "  \"error\": {\n"
+        + "    \"code\": 402,\n"
+        + "    \"status\": \"FAILED_PRECONDITION\"\n"
+        + "  }\n"
+        + "}";
+
+    ErrorMessage em = mapper.readValue(json, ErrorMessage.class);
+
+    assertThat(em).isNotNull();
+    assertThat(em.getErrorCode()).isEqualTo(402);
+    assertThat(em.getMessage()).isEqualTo("FAILED_PRECONDITION");
+  }
+
+  @Test
+  public void success_parseNestedAndUnnestedFields() throws Exception {
+    String json = "{\n"
+        + "  \"error_code\": 401,\n"
+        + "  \"message\": \"parseUnnestedFields\",\n"
+        + "  \"error\": {\n"
+        + "    \"code\": 402,\n"
+        + "    \"message\": \"parseNestedFields\",\n"
+        + "    \"status\": \"FAILED_PRECONDITION\"\n"
+        + "  }\n"
+        + "}";
+
+    ErrorMessage em = mapper.readValue(json, ErrorMessage.class);
+
+    assertThat(em).isNotNull();
+    assertThat(em.getErrorCode()).isEqualTo(402);
+    assertThat(em.getMessage()).isEqualTo("FAILED_PRECONDITION: parseNestedFields");
+  }
+
+  @Test
+  public void fail_badJsonFormat() {
+    String json = "{\n"
+        + "  \"error\": {\n"
+        + "    \"code\": 402\n"
+        + "    \"message\": \"parseNestedFields\"\n"
+        + "  }\n"
+        + "}";
+
+    assertThrows(JsonMappingException.class, () -> mapper.readValue(json, ErrorMessage.class));
+  }
+}


### PR DESCRIPTION
Adding a modified version of io.confluent.kafka.schemaregistry.client.rest.entities.ErrorMessage from the Confluent Schema Registry Client, which has the same structure in Java and is still fully compatible with the client code, but supports parsing the source JSON error message in more formats via Jackson annotations.

Pre-pending this auth library to the classpath of an application using a Schema Registry client will override the class implementation and will allow parsing Managed Kafka style error messages.

If using Maven, this can be achieved by adding this dependency **first** in the pom.xml file:
```
<dependencies>
    <dependency>
      <groupId>com.google.cloud.hosted.kafka</groupId>
      <artifactId>managed-kafka-auth-login-handler</artifactId>
      <version>1.0.6</version>
    </dependency>
    ... other dependencies ...
</dependencies>
```
If running an existing application from the command line, the jar file needs to be pre-pended to the classpath:
```
java -cp managed-kafka-auth-login-handler-1.0.6.jar:<other class path entries> <main class>
```