### PR TITLE
chore: Add requirements.txt for kafka-auth-local-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,7 @@ In order to use this library, you should:
 pip install virtualenv
 virtualenv <your-env>
 source <your-env>/bin/activate
-<your-env>/bin/pip install packaging
-<your-env>/bin/pip install urllib3
-<your-env>/bin/pip install google-auth
+<your-env>/bin/pip install -r kafka-auth-local-server/requirements.txt
 ```
 
 2. Run the server.

--- a/kafka-auth-local-server/requirements.txt
+++ b/kafka-auth-local-server/requirements.txt
@@ -1,0 +1,1 @@
+google-auth[urllib3]>=2.40.3


### PR DESCRIPTION
Add `requirements.txt` for kafka-auth-local-server.

This is to ensure that we use [google-auth 2.40.3](https://github.com/googleapis/google-auth-library-python/releases/tag/v2.40.3) or later which is required for GKE WIF support.

Internal bug: b/385138184