### PR TITLE
feat: Python auth local server - Add new `GOOGLE_MANAGED_KAFKA_AUTH_PRINCIPAL` environment variable that allows users to provide the auth principal for credential types where it cannot be programmatically fetched

### DIFF
--- a/kafka-auth-local-server/kafka_gcp_credentials_server.py
+++ b/kafka-auth-local-server/kafka_gcp_credentials_server.py
@@ -19,9 +19,8 @@ import datetime
 import http.server
 import json
 import google.auth
-import google.auth.crypt
-import google.auth.jwt
 import google.auth.transport.urllib3
+import os
 import urllib3
 
 
@@ -41,12 +40,21 @@ _HEADER = json.dumps(dict(typ='JWT', alg='GOOG_OAUTH2_TOKEN'))
 
 
 def get_jwt(creds):
+  subject = getattr(creds, 'service_account_email', None)
+  if not subject:
+      env_principal = os.environ.get('GOOGLE_MANAGED_KAFKA_AUTH_PRINCIPAL')
+      if not env_principal:
+          raise ValueError(
+          'Unable to determine principal for credentials. Please set the '
+          'GOOGLE_MANAGED_KAFKA_AUTH_PRINCIPAL environment variable'
+        )
+      subject = env_principal
   return json.dumps(
       dict(
           exp=creds.expiry.replace(tzinfo=datetime.timezone.utc).timestamp(),
           iss='Google',
           iat=datetime.datetime.now(datetime.timezone.utc).timestamp(),
-          sub=creds.service_account_email,
+          sub=subject,
       )
   )
 

--- a/kafka-auth-local-server/kafka_gcp_credentials_server.py
+++ b/kafka-auth-local-server/kafka_gcp_credentials_server.py
@@ -40,15 +40,14 @@ _HEADER = json.dumps(dict(typ='JWT', alg='GOOG_OAUTH2_TOKEN'))
 
 
 def get_jwt(creds):
-  subject = getattr(creds, 'service_account_email', None)
+  subject = os.environ.get('GOOGLE_MANAGED_KAFKA_AUTH_PRINCIPAL')
   if not subject:
-      env_principal = os.environ.get('GOOGLE_MANAGED_KAFKA_AUTH_PRINCIPAL')
-      if not env_principal:
-          raise ValueError(
+      subject = getattr(creds, 'service_account_email', None)
+  if not subject:
+      raise ValueError(
           'Unable to determine principal for credentials. Please set the '
           'GOOGLE_MANAGED_KAFKA_AUTH_PRINCIPAL environment variable'
-        )
-      subject = env_principal
+      )
   return json.dumps(
       dict(
           exp=creds.expiry.replace(tzinfo=datetime.timezone.utc).timestamp(),

--- a/kafka-auth-local-server/requirements.txt
+++ b/kafka-auth-local-server/requirements.txt
@@ -1,1 +1,1 @@
-google-auth[urllib3]>=2.40.3
+google-auth[requests,urllib3]>=2.40.3


### PR DESCRIPTION
Add new `GOOGLE_MANAGED_KAFKA_AUTH_PRINCIPAL` environment variable for principal override. This allows users to provide the auth principal for credential types where it cannot be programmatically fetched.

This allows the auth server to be used with BYOID credential types such as Workforce Identity Federation.

Also dropped 2 imports that are not used and added `requests` which the auth library needs for fetching some BYOID tokens.

Googlers see [b/449376528#comment13](http://b/449376528#comment13) for more details.


