### PR TITLE
chore: replace old partner teams with updated names

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*   @googleapis/managedkafka
+*   @googleapis/managed-kafka-team

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -35,5 +35,5 @@ branchProtectionRules:
 
 # Set team access
 permissionRules:
-  - team: managedkafka
+  - team: managed-kafka-team
     permission: admin


### PR DESCRIPTION
This PR replaces @googleapis/managedkafka with @googleapis/managed-kafka-team. b/478003109